### PR TITLE
[ENH] Add repo urls as meta information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,4 +56,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
+    project_urls={
+        'Source': 'https://github.com/cgohlke/sdtfile',
+        'Tracker': 'https://github.com/cgohlke/sdtfile/issues',
+    },
 )


### PR DESCRIPTION
This adds urls to this repo as meta information, which will be shown at PyPi and make it easier for users to discover the repo.