### PR TITLE
[BUG] Fix datatype overflow causing negative values for times

### DIFF
--- a/sdtfile/sdtfile.py
+++ b/sdtfile/sdtfile.py
@@ -276,7 +276,7 @@ class SdtFile:
             else:
                 # generate time axis
                 t = numpy.arange(adc_re, dtype='float64')
-                t *= mi.tac_r / float(mi.tac_g * adc_re)
+                t *= mi.tac_r / (float(mi.tac_g) * adc_re)
             self.times.append(t)
             offset = bh.next_block_offs
 


### PR DESCRIPTION
Hi there, we are currently [transitioning](https://github.com/glotaran/pyglotaran/issues/387) from using our old copy of your code to using your PyPi package (we somehow overlooked back then).
While doing so I found a bug, that I [back then fixed in our copy](https://github.com/s-weigand/pyglotaran/commit/7d3ac5df6f7024c9b164c0b153ff05a6046e9145#diff-c0cd96878e41f6728e4a798f54bdb07e) (I also somehow overlooked your repo 😓 ).
That bug is causing the values of times for our test file to be negative, so I did some digging and came up with a solution.
As the caption says the root of the problem is a datatype overflow in a numpy int16 array.

See this example to recreate the issue:
https://github.com/s-weigand/sdtfile/blob/example/example/example.ipynb
And the zipped version for reproducibilitys sake in the backlog.
[example.zip](https://github.com/cgohlke/sdtfile/files/5016440/example.zip)

P.S.: Atm we are backtracking, which publication the file belongs to and when we got that we are happy to share it with you as a testcase. So we all can be unicorns, that is tested software in science .🦄 