### PR TITLE
Start parsing binary setup

### DIFF
--- a/sdtfile/sdtfile.py
+++ b/sdtfile/sdtfile.py
@@ -439,13 +439,13 @@ class SetupBlock:
     """Binary data."""
     
     BHBinHDR: numpy.recarray[Any, Any]
-    """File header of type FILE_HEADER."""
+    """binary setup header of type SETUP_BIN_HDR."""
     
     SPCBinHDR: numpy.recarray[Any, Any]
-    """File header of type FILE_HEADER."""
+    """binary setup header of type SETUP_BIN_SPCHDR."""
     
     SPCBinGVDParam: numpy.recarray[Any, Any]
-    """File header of type FILE_HEADER."""
+    """binary setup block of type SETUP_BIN_GVDParam."""
     def __init__(self, value: bytes, /) -> None:
         assert value.startswith(b'*SETUP') and value.strip().endswith(b'*END')
         i = value.find(b'BIN_PARA_BEGIN')

--- a/sdtfile/sdtfile.py
+++ b/sdtfile/sdtfile.py
@@ -467,13 +467,14 @@ class SetupBlock:
                 shape=1,
                 byteorder='<',
             )[0]
-            startGVDParam = self.SPCBinHDR["GVD_offs"]+startOfSetup
-            self.SPCBinGVDParam = numpy.rec.fromstring(
-                value[startGVDParam:startGVDParam+numpy.dtype(SETUP_BIN_GVDParam).itemsize],
-                dtype=SETUP_BIN_GVDParam,
-                shape=1,
-                byteorder='<',
-            )[0]
+            if (self.BHBinHDR['soft_rev'] in [985,988]):
+                startGVDParam = self.SPCBinHDR["GVD_offs"]+startOfSetup
+                self.SPCBinGVDParam = numpy.rec.fromstring(
+                    value[startGVDParam:startGVDParam+self.SPCBinHDR["GVD_size"]],
+                    dtype=SETUP_BIN_GVDParam,
+                    shape=1,
+                    byteorder='<',
+                )[0]
             # TODO: parse binary data here
         else:
             self.ascii = value.decode('windows-1250')
@@ -651,6 +652,20 @@ SETUP_BIN_SPCHDR: list[tuple[str, str]] = [
     ('binhdrext_size', 'u2'),
 ]
 
+SETUP_BIN_BHPanelAttr: list[tuple[str, str]] = [
+    ('top', 'i4'),
+    ('left', 'i4'),
+    ('height', 'i4'),
+    ('width', 'i4'),
+    ('flags', 'i4'),
+]
+
+SETUP_BIN_BHPanelData: list[tuple[str, str]] = [
+    ('status', 'i4'),
+    ('name', 'S20'),
+    ('data', SETUP_BIN_BHPanelAttr),
+]
+
 SETUP_BIN_GVDdata: list[tuple[str, str]] = [
     ('active', 'i2'),
     ('frame_size', 'u2'),
@@ -688,7 +703,7 @@ SETUP_BIN_GVDParam: list[tuple[str, str]] = [
     ('gvd_data', SETUP_BIN_GVDdata),
     ('DAC_per_step', 'u2'),
     ('line_pulse_shift', 'i2'),
-    #omitted BHPanelAttr here
+    ('pnl_attr',SETUP_BIN_BHPanelAttr)
 ]
 
 


### PR DESCRIPTION
I personally use the parameters included in the GVDparams section of the file, to ensure proper scaling. Count scaling depends on laserpower, linetime and number frames, and lateral scaling depends on the zoom factor. These variables are included in the binary setup, but are not parsed in the current version of sdtfile. I added the definitions and parsed them in a way I thought fits the rest of the package.

The rest of the binary setup is not included since I do not know what they mean, and can not verify that they work as intended. The parts that are included, I have tested against FLIM files from our setup.